### PR TITLE
Allow over/under flow for 1D histograms

### DIFF
--- a/pygram11/_core.cpp
+++ b/pygram11/_core.cpp
@@ -97,7 +97,7 @@ bool has_OpenMP() {
 template <typename T>
 py::array_t<T> py_fix1d(py::array_t<T, py::array::c_style | py::array::forcecast> x,
                         int nbins, T xmin, T xmax, bool use_omp) {
-  auto result_count = py::array_t<std::int64_t>(nbins);
+  auto result_count = py::array_t<std::int64_t>(nbins + 2);
   std::int64_t* result_count_ptr = result_count.mutable_data();
   std::size_t ndata = static_cast<std::size_t>(x.size());
 
@@ -115,8 +115,8 @@ template <typename T>
 py::tuple py_fix1d_weighted(py::array_t<T, py::array::c_style | py::array::forcecast> x,
                             py::array_t<T, py::array::c_style | py::array::forcecast> w,
                             int nbins, T xmin, T xmax, bool use_omp) {
-  auto result_count = py::array_t<T>(nbins);
-  auto result_sumw2 = py::array_t<T>(nbins);
+  auto result_count = py::array_t<T>(nbins + 2);
+  auto result_sumw2 = py::array_t<T>(nbins + 2);
   T* result_count_ptr = result_count.mutable_data();
   T* result_sumw2_ptr = result_sumw2.mutable_data();
   std::size_t ndata = static_cast<std::size_t>(x.size());
@@ -149,7 +149,7 @@ py::array_t<T> py_var1d(py::array_t<T, py::array::c_style | py::array::forcecast
   std::size_t ndata = static_cast<std::size_t>(x.size());
   int nbins = edges_len - 1;
 
-  auto result_count = py::array_t<std::int64_t>(nbins);
+  auto result_count = py::array_t<std::int64_t>(nbins + 2);
   std::int64_t* result_count_ptr = result_count.mutable_data();
 
 #ifdef PYGRAMUSEOMP
@@ -174,8 +174,8 @@ py::tuple py_var1d_weighted(py::array_t<T, py::array::c_style | py::array::force
   std::size_t ndata = static_cast<std::size_t>(x.size());
   std::size_t nbins = edges_len - 1;
 
-  auto result_count = py::array_t<T>(nbins);
-  auto result_sumw2 = py::array_t<T>(nbins);
+  auto result_count = py::array_t<T>(nbins + 2);
+  auto result_sumw2 = py::array_t<T>(nbins + 2);
   T* result_count_ptr = result_count.mutable_data();
   T* result_sumw2_ptr = result_sumw2.mutable_data();
   py::list listing;

--- a/pygram11/_core1d.hpp
+++ b/pygram11/_core1d.hpp
@@ -21,15 +21,15 @@ void c_fix1d_weighted_omp(const T* data, const T* weights, T* count, T* sumw2,
                           const std::size_t n, const int nbins, const T xmin,
                           const T xmax) {
   const T norm = 1.0 / (xmax - xmin);
-  memset(count, 0, sizeof(T) * nbins);
-  memset(sumw2, 0, sizeof(T) * nbins);
+  memset(count, 0, sizeof(T) * (nbins + 2));
+  memset(sumw2, 0, sizeof(T) * (nbins + 2));
 
 #pragma omp parallel
   {
-    std::unique_ptr<T[]> count_priv(new T[nbins]);
-    std::unique_ptr<T[]> sumw2_priv(new T[nbins]);
-    memset(count_priv.get(), 0, sizeof(T) * nbins);
-    memset(sumw2_priv.get(), 0, sizeof(T) * nbins);
+    std::unique_ptr<T[]> count_priv(new T[nbins + 2]);
+    std::unique_ptr<T[]> sumw2_priv(new T[nbins + 2]);
+    memset(count_priv.get(), 0, sizeof(T) * (nbins + 2));
+    memset(sumw2_priv.get(), 0, sizeof(T) * (nbins + 2));
 
 #pragma omp for nowait
     for (std::size_t i = 0; i < n; i++) {
@@ -38,7 +38,7 @@ void c_fix1d_weighted_omp(const T* data, const T* weights, T* count, T* sumw2,
     }
 
 #pragma omp critical
-    for (int i = 0; i < nbins; i++) {
+    for (int i = 0; i < (nbins + 2); i++) {
       count[i] += count_priv[i];
       sumw2[i] += sumw2_priv[i];
     }
@@ -50,8 +50,8 @@ template <typename T>
 void c_fix1d_weighted(const T* data, const T* weights, T* count, T* sumw2,
                       const std::size_t n, const int nbins, const T xmin, const T xmax) {
   const T norm = 1.0 / (xmax - xmin);
-  memset(count, 0, sizeof(T) * nbins);
-  memset(sumw2, 0, sizeof(T) * nbins);
+  memset(count, 0, sizeof(T) * (nbins + 2));
+  memset(sumw2, 0, sizeof(T) * (nbins + 2));
   for (std::size_t i = 0; i < n; i++) {
     pygram11::detail::fill(count, sumw2, data[i], weights[i], nbins, norm, xmin, xmax);
   }
@@ -62,12 +62,12 @@ template <typename T>
 void c_fix1d_omp(const T* data, std::int64_t* count, const std::size_t n, const int nbins,
                  const T xmin, const T xmax) {
   const T norm = 1.0 / (xmax - xmin);
-  memset(count, 0, sizeof(std::int64_t) * nbins);
+  memset(count, 0, sizeof(std::int64_t) * (nbins + 2));
 
 #pragma omp parallel
   {
-    std::unique_ptr<std::int64_t[]> count_priv(new std::int64_t[nbins]);
-    memset(count_priv.get(), 0, sizeof(std::int64_t) * nbins);
+    std::unique_ptr<std::int64_t[]> count_priv(new std::int64_t[nbins + 2]);
+    memset(count_priv.get(), 0, sizeof(std::int64_t) * (nbins + 2));
 
 #pragma omp for nowait
     for (std::size_t i = 0; i < n; i++) {
@@ -86,7 +86,7 @@ template <typename T>
 void c_fix1d(const T* data, std::int64_t* count, const std::size_t n, const int nbins,
              const T xmin, const T xmax) {
   const T norm = 1.0 / (xmax - xmin);
-  memset(count, 0, sizeof(std::int64_t) * nbins);
+  memset(count, 0, sizeof(std::int64_t) * (nbins + 2));
   for (std::size_t i = 0; i < n; i++) {
     pygram11::detail::fill(count, data[i], nbins, norm, xmin, xmax);
   }
@@ -106,10 +106,10 @@ void c_var1d_weighted_omp(const T* data, const T* weights, T* count, T* sumw2,
 
 #pragma omp parallel
   {
-    std::unique_ptr<T[]> count_priv(new T[nbins]);
-    std::unique_ptr<T[]> sumw2_priv(new T[nbins]);
-    memset(count_priv.get(), 0, sizeof(T) * nbins);
-    memset(sumw2_priv.get(), 0, sizeof(T) * nbins);
+    std::unique_ptr<T[]> count_priv(new T[nbins + 2]);
+    std::unique_ptr<T[]> sumw2_priv(new T[nbins + 2]);
+    memset(count_priv.get(), 0, sizeof(T) * (nbins + 2));
+    memset(sumw2_priv.get(), 0, sizeof(T) * (nbins + 2));
 
 #pragma omp for nowait
     for (std::size_t i = 0; i < n; i++) {
@@ -129,8 +129,8 @@ void c_var1d_weighted_omp(const T* data, const T* weights, T* count, T* sumw2,
 template <typename T>
 void c_var1d_weighted(const T* data, const T* weights, T* count, T* sumw2,
                       const std::size_t n, const int nbins, const std::vector<T>& edges) {
-  memset(count, 0, sizeof(T) * nbins);
-  memset(sumw2, 0, sizeof(T) * nbins);
+  memset(count, 0, sizeof(T) * (nbins + 2));
+  memset(sumw2, 0, sizeof(T) * (nbins + 2));
   for (std::size_t i = 0; i < n; i++) {
     pygram11::detail::fill(count, sumw2, data[i], weights[i], nbins, edges);
   }
@@ -143,8 +143,8 @@ void c_var1d_omp(const T* data, std::int64_t* count, const std::size_t n, const 
   memset(count, 0, sizeof(std::int64_t) * nbins);
 #pragma omp parallel
   {
-    std::unique_ptr<std::int64_t[]> count_priv(new std::int64_t[nbins]);
-    memset(count_priv.get(), 0, sizeof(std::int64_t) * nbins);
+    std::unique_ptr<std::int64_t[]> count_priv(new std::int64_t[nbins + 2]);
+    memset(count_priv.get(), 0, sizeof(std::int64_t) * (nbins + 2));
 
 #pragma omp for nowait
     for (std::size_t i = 0; i < n; i++) {
@@ -162,7 +162,7 @@ void c_var1d_omp(const T* data, std::int64_t* count, const std::size_t n, const 
 template <typename T>
 void c_var1d(const T* data, std::int64_t* count, const std::size_t n, const int nbins,
              const std::vector<T>& edges) {
-  memset(count, 0, sizeof(std::int64_t) * nbins);
+  memset(count, 0, sizeof(std::int64_t) * (nbins + 2));
   for (std::size_t i = 0; i < n; i++) {
     pygram11::detail::fill(count, data[i], nbins, edges);
   }

--- a/pygram11/_core1d.hpp
+++ b/pygram11/_core1d.hpp
@@ -75,7 +75,7 @@ void c_fix1d_omp(const T* data, std::int64_t* count, const std::size_t n, const 
     }
 
 #pragma omp critical
-    for (int i = 0; i < nbins; i++) {
+    for (int i = 0; i < (nbins + 2); i++) {
       count[i] += count_priv[i];
     }
   }
@@ -101,8 +101,8 @@ template <typename T>
 void c_var1d_weighted_omp(const T* data, const T* weights, T* count, T* sumw2,
                           const std::size_t n, const int nbins,
                           const std::vector<T>& edges) {
-  memset(count, 0, sizeof(T) * nbins);
-  memset(sumw2, 0, sizeof(T) * nbins);
+  memset(count, 0, sizeof(T) * (nbins + 2));
+  memset(sumw2, 0, sizeof(T) * (nbins + 2));
 
 #pragma omp parallel
   {
@@ -118,7 +118,7 @@ void c_var1d_weighted_omp(const T* data, const T* weights, T* count, T* sumw2,
     }
 
 #pragma omp critical
-    for (int i = 0; i < nbins; i++) {
+    for (int i = 0; i < (nbins + 2); i++) {
       count[i] += count_priv[i];
       sumw2[i] += sumw2_priv[i];
     }
@@ -140,7 +140,7 @@ void c_var1d_weighted(const T* data, const T* weights, T* count, T* sumw2,
 template <typename T>
 void c_var1d_omp(const T* data, std::int64_t* count, const std::size_t n, const int nbins,
                  const std::vector<T>& edges) {
-  memset(count, 0, sizeof(std::int64_t) * nbins);
+  memset(count, 0, sizeof(std::int64_t) * (nbins + 2));
 #pragma omp parallel
   {
     std::unique_ptr<std::int64_t[]> count_priv(new std::int64_t[nbins + 2]);
@@ -152,7 +152,7 @@ void c_var1d_omp(const T* data, std::int64_t* count, const std::size_t n, const 
     }
 
 #pragma omp critical
-    for (int i = 0; i < nbins; i++) {
+    for (int i = 0; i < (nbins + 2); i++) {
       count[i] += count_priv[i];
     }
   }

--- a/pygram11/_utils.hpp
+++ b/pygram11/_utils.hpp
@@ -24,37 +24,69 @@ typename FItr::difference_type nonuniform_bin_find(FItr first, FItr last, const 
 template <typename T>
 void fill(T* count, T* sumw2, const T x, const T weight, const int nbins, const T norm,
           const T xmin, const T xmax) {
-  if (!(x >= xmin && x < xmax)) return;
-  std::size_t binId = (x - xmin) * norm * nbins;
-  count[binId] += weight;
-  sumw2[binId] += weight * weight;
+  if (x < xmin) {
+    count[0] += weight;
+    sumw2[0] += weight * weight;
+  }
+  else if (x > xmax) {
+    count[nbins + 1] += weight;
+    sumw2[nbins + 1] += weight * weight;
+  }
+  else {
+    std::size_t binId = (x - xmin) * norm * nbins;
+    count[binId + 1] += weight;
+    sumw2[binId + 1] += weight * weight;
+  }
 }
 
 /// fill a fixed bin width unweighted 1d histogram
 template <typename T>
 void fill(std::int64_t* count, const T x, const int nbins, const T norm, const T xmin,
           const T xmax) {
-  if (!(x >= xmin && x < xmax)) return;
-  std::size_t binId = (x - xmin) * norm * nbins;
-  count[binId]++;
+  if (x < xmin) {
+    ++count[0];
+  }
+  else if (x > xmax) {
+    ++count[nbins + 1];
+  }
+  else {
+    std::size_t binId = (x - xmin) * norm * nbins;
+    ++count[binId + 1];
+  }
 }
 
 /// fill a variable bin width weighted 1d histogram
 template <typename T>
 void fill(T* count, T* sumw2, const T x, const T weight, const int nbins,
           const std::vector<T>& edges) {
-  if (!(x >= edges[0] && x < edges[nbins])) return;
-  std::size_t binId = nonuniform_bin_find(std::begin(edges), std::end(edges), x);
-  count[binId] += weight;
-  sumw2[binId] += weight * weight;
+  if (x < edges[0]) {
+    count[0] += weight;
+    sumw2[0] += weight * weight;
+  }
+  else if (x > edges.back()) {
+    count[nbins + 1] += weight;
+    sumw2[nbins + 1] += weight * weight;
+  }
+  else {
+    std::size_t binId = nonuniform_bin_find(std::begin(edges), std::end(edges), x);
+    count[binId + 1] += weight;
+    sumw2[binId + 1] += weight * weight;
+  }
 }
 
 /// fill a variable bin width unweighted 1d histogram
 template <typename T>
 void fill(std::int64_t* count, const T x, const int nbins, const std::vector<T>& edges) {
-  if (!(x >= edges[0] && x < edges[nbins])) return;
-  std::size_t binId = nonuniform_bin_find(std::begin(edges), std::end(edges), x);
-  count[binId]++;
+  if (x < edges[0]) {
+    ++count[0];
+  }
+  else if (x > edges.back()) {
+    ++count[nbins + 1];
+  }
+  else {
+    std::size_t binId = nonuniform_bin_find(std::begin(edges), std::end(edges), x);
+    ++count[binId + 1];
+  }
 }
 
 /// fill a fixed bin width weighted 2d histogram

--- a/pygram11/_utils.hpp
+++ b/pygram11/_utils.hpp
@@ -24,69 +24,69 @@ typename FItr::difference_type nonuniform_bin_find(FItr first, FItr last, const 
 template <typename T>
 void fill(T* count, T* sumw2, const T x, const T weight, const int nbins, const T norm,
           const T xmin, const T xmax) {
+  std::size_t binId;
   if (x < xmin) {
-    count[0] += weight;
-    sumw2[0] += weight * weight;
+    binId = 0;
   }
   else if (x > xmax) {
-    count[nbins + 1] += weight;
-    sumw2[nbins + 1] += weight * weight;
+    binId = nbins + 1;
   }
   else {
-    std::size_t binId = (x - xmin) * norm * nbins;
-    count[binId + 1] += weight;
-    sumw2[binId + 1] += weight * weight;
+    binId = static_cast<std::size_t>((x - xmin) * norm * nbins) + 1;
   }
+  count[binId] += weight;
+  sumw2[binId] += weight * weight;
 }
 
 /// fill a fixed bin width unweighted 1d histogram
 template <typename T>
 void fill(std::int64_t* count, const T x, const int nbins, const T norm, const T xmin,
           const T xmax) {
+  std::size_t binId;
   if (x < xmin) {
-    ++count[0];
+    binId = 0;
   }
   else if (x > xmax) {
-    ++count[nbins + 1];
+    binId = nbins + 1;
   }
   else {
-    std::size_t binId = (x - xmin) * norm * nbins;
-    ++count[binId + 1];
+    binId = static_cast<std::size_t>((x - xmin) * norm * nbins) + 1;
   }
+  ++count[binId];
 }
 
 /// fill a variable bin width weighted 1d histogram
 template <typename T>
 void fill(T* count, T* sumw2, const T x, const T weight, const int nbins,
           const std::vector<T>& edges) {
+  std::size_t binId;
   if (x < edges[0]) {
-    count[0] += weight;
-    sumw2[0] += weight * weight;
+    binId = 0;
   }
   else if (x > edges.back()) {
-    count[nbins + 1] += weight;
-    sumw2[nbins + 1] += weight * weight;
+    binId = nbins + 1;
   }
   else {
-    std::size_t binId = nonuniform_bin_find(std::begin(edges), std::end(edges), x);
-    count[binId + 1] += weight;
-    sumw2[binId + 1] += weight * weight;
+    binId = nonuniform_bin_find(std::begin(edges), std::end(edges), x) + 1;
   }
+  count[binId] += weight;
+  sumw2[binId] += weight * weight;
 }
 
 /// fill a variable bin width unweighted 1d histogram
 template <typename T>
 void fill(std::int64_t* count, const T x, const int nbins, const std::vector<T>& edges) {
+  std::size_t binId;
   if (x < edges[0]) {
-    ++count[0];
+    binId = 0;
   }
   else if (x > edges.back()) {
-    ++count[nbins + 1];
+    binId = nbins + 1;
   }
   else {
-    std::size_t binId = nonuniform_bin_find(std::begin(edges), std::end(edges), x);
-    ++count[binId + 1];
+    binId = nonuniform_bin_find(std::begin(edges), std::end(edges), x) + 1;
   }
+  ++count[binId];
 }
 
 /// fill a fixed bin width weighted 2d histogram
@@ -96,8 +96,8 @@ void fill(T* count, T* sumw2, const T x, const T y, const T weight, const T norm
           const T ymin, const T ymax) {
   if (!(x >= xmin && x < xmax)) return;
   if (!(y >= ymin && y < ymax)) return;
-  std::size_t xbinId = (x - xmin) * normx * nbinsx;
-  std::size_t ybinId = (y - ymin) * normy * nbinsy;
+  std::size_t xbinId = static_cast<std::size_t>((x - xmin) * normx * nbinsx);
+  std::size_t ybinId = static_cast<std::size_t>((y - ymin) * normy * nbinsy);
   count[ybinId + nbinsy * xbinId] += weight;
   sumw2[ybinId + nbinsy * xbinId] += weight * weight;
 }

--- a/pygram11/hist.py
+++ b/pygram11/hist.py
@@ -24,7 +24,7 @@ import numpy as np
 import numbers
 
 
-def fix1d(x, bins=10, range=None, weights=None, density=False, omp="auto"):
+def fix1d(x, bins=10, range=None, weights=None, density=False, flow=False, omp="auto"):
     """histogram ``x`` with fixed (uniform) binning over a range
     [xmin, xmax).
 
@@ -92,6 +92,11 @@ def fix1d(x, bins=10, range=None, weights=None, density=False, omp="auto"):
     else:
         result = unweight_func(x, bins, range[0], range[1], use_omp)
 
+    if not flow:
+        result = result[1:-1]
+        if weights is not None:
+            sw2 = sw2[1:-1]
+
     if density:
         if weights is None:
             sw2 = None
@@ -99,10 +104,11 @@ def fix1d(x, bins=10, range=None, weights=None, density=False, omp="auto"):
 
     if weights is None:
         return result
+
     return result, np.sqrt(sw2)
 
 
-def var1d(x, bins, weights=None, density=False, omp="auto"):
+def var1d(x, bins, weights=None, density=False, flow=False, omp="auto"):
     """histogram ``x`` with variable (non-uniform) binning over a range
     [bins[0], bins[-1]).
 
@@ -165,6 +171,12 @@ def var1d(x, bins, weights=None, density=False, omp="auto"):
         result, sw2 = weighted_func(x, weights, bins, use_omp)
     else:
         result = unweight_func(x, bins, use_omp)
+
+
+    if not flow:
+        result = result[1:-1]
+        if weights is not None:
+            sw2 = sw2[1:-1]
 
     if density:
         if weights is None:
@@ -304,7 +316,7 @@ def var2d(x, y, xbins, ybins, weights=None, omp=False):
         return unweight_func(x, y, xbins, ybins, omp)
 
 
-def histogram(x, bins=10, range=None, weights=None, density=False, omp="auto"):
+def histogram(x, bins=10, range=None, weights=None, density=False, flow=False, omp="auto"):
     """Compute the histogram for the data ``x``.
 
     This function provides an API very simiar to
@@ -348,10 +360,10 @@ def histogram(x, bins=10, range=None, weights=None, density=False, omp="auto"):
     """
     if isinstance(bins, numbers.Integral):
         return fix1d(
-            x, bins=bins, range=range, weights=weights, density=density, omp=omp
+            x, bins=bins, range=range, weights=weights, density=density, flow=flow, omp=omp
         )
     else:
-        return var1d(x, bins, weights=weights, density=density, omp=omp)
+        return var1d(x, bins, weights=weights, density=density, flow=flow, omp=omp)
 
 
 def histogram2d(x, y, bins=10, range=None, weights=None, omp=False):

--- a/pygram11/hist.py
+++ b/pygram11/hist.py
@@ -41,6 +41,9 @@ def fix1d(x, bins=10, range=None, weights=None, density=False, flow=False, omp="
     density: bool
         normalize histogram bins as value of PDF such that the integral
         over the range is 1.
+    flow: bool
+        if ``True`` the under and overflow bin contents are added to the first
+        and last bins, respectively
     omp: bool or str
         if ``True``, use OpenMP if available; if "auto" (and OpenMP is available),
         enables OpenMP if len(x) > 10^4
@@ -129,6 +132,9 @@ def var1d(x, bins, weights=None, density=False, flow=False, omp="auto"):
     density: bool
         normalize histogram bins as value of PDF such that the integral
         over the range is 1.
+    flow: bool
+        if ``True`` the under and overflow bin contents are added to the first
+        and last bins, respectively
     omp: bool or str
         if ``True``, use OpenMP if available; if "auto" (and OpenMP is available),
         enables OpenMP if len(x) > 10^3
@@ -356,6 +362,9 @@ def histogram(x, bins=10, range=None, weights=None, density=False, flow=False, o
     density: bool
         normalize histogram bins as value of PDF such that the integral
         over the range is 1.
+    flow: bool
+        if ``True`` the under and overflow bin contents are added to the first
+        and last bins, respectively
     omp: bool or str
         if ``True``, use OpenMP if available; if "auto" (and OpenMP is available),
         enables OpenMP if len(x) > 10^4 for fixed width and > 10^3 for variable

--- a/pygram11/hist.py
+++ b/pygram11/hist.py
@@ -92,10 +92,16 @@ def fix1d(x, bins=10, range=None, weights=None, density=False, flow=False, omp="
     else:
         result = unweight_func(x, bins, range[0], range[1], use_omp)
 
-    if not flow:
-        result = result[1:-1]
+    if flow:
+        result[1] += result[0]
+        result[-2] += result[-1]
         if weights is not None:
-            sw2 = sw2[1:-1]
+            sw2[1] += sw2[0]
+            sw2[-1] += sw2[-2]
+
+    result = result[1:-1]
+    if weights is not None:
+        sw2 = sw2[1:-1]
 
     if density:
         if weights is None:
@@ -172,11 +178,16 @@ def var1d(x, bins, weights=None, density=False, flow=False, omp="auto"):
     else:
         result = unweight_func(x, bins, use_omp)
 
-
-    if not flow:
-        result = result[1:-1]
+    if flow:
+        result[1] += result[0]
+        result[-2] += result[-1]
         if weights is not None:
-            sw2 = sw2[1:-1]
+            sw2[1] += sw2[0]
+            sw2[-1] += sw2[-2]
+
+    result = result[1:-1]
+    if weights is not None:
+        sw2 = sw2[1:-1]
 
     if density:
         if weights is None:

--- a/tests/test_histogram.py
+++ b/tests/test_histogram.py
@@ -221,3 +221,56 @@ def test_density_var1d():
     pygram_h, _ = pygram11.var1d(x, bins=bins, weights=w, density=True)
     numpy_h, _ = np.histogram(x, bins=bins, weights=w, density=True)
     npt.assert_almost_equal(pygram_h, numpy_h, 5)
+
+
+def test_flow_weights():
+    x = np.random.randn(100000)
+    w = np.random.uniform(0.5, 0.8, x.shape[0])
+    nbins = 50
+    rg = (-3, 3)
+    pygram_h, _ = pygram11.histogram(x, bins=nbins, range=rg, weights=w, omp=False, flow=True)
+    numpy_h, _ = np.histogram(x, bins=nbins, range=rg, weights=w)
+
+    numpy_h[0] += sum(w[x < rg[0]])
+    numpy_h[-1] += sum(w[x > rg[1]])
+
+    assert np.allclose(pygram_h, numpy_h)
+
+def test_flow():
+    x = np.random.randn(100000)
+
+    nbins = 50
+    rg = (-3, 3)
+    pygram_h = pygram11.histogram(x, bins=nbins, range=rg, omp=False, flow=True)
+    numpy_h, _ = np.histogram(x, bins=nbins, range=rg)
+
+    numpy_h[0] += sum(x < rg[0])
+    numpy_h[-1] += sum(x > rg[1])
+
+    assert np.all(pygram_h == numpy_h)
+
+if pygram11.OPENMP:
+    def test_flow_weights_omp():
+        x = np.random.randn(100000)
+        w = np.random.uniform(0.5, 0.8, x.shape[0])
+        nbins = 50
+        rg = (-3, 3)
+        pygram_h, _ = pygram11.histogram(x, bins=nbins, range=rg, weights=w, omp=True, flow=True)
+        numpy_h, _ = np.histogram(x, bins=nbins, range=rg, weights=w)
+
+        numpy_h[0] += sum(w[x < rg[0]])
+        numpy_h[-1] += sum(w[x > rg[1]])
+
+        assert np.allclose(pygram_h, numpy_h)
+
+    def test_flow_omp():
+        x = np.random.randn(100000)
+        nbins = 50
+        rg = (-3, 3)
+        pygram_h = pygram11.histogram(x, bins=nbins, range=rg, omp=True, flow=True)
+        numpy_h, _ = np.histogram(x, bins=nbins, range=rg)
+
+        numpy_h[0] += sum(x < rg[0])
+        numpy_h[-1] += sum(x > rg[1])
+
+        assert np.all(pygram_h == numpy_h)


### PR DESCRIPTION
- extend the number of bins in memory by 2
- fill bin 0 for data less than xmin
- fill bin nbins + 1 for data larger than than xmax
- first real bin is now index 1
- last real bin is now index nbins
- add named arguments to python functions which dictate how to slice result so we return the desired bin counts.